### PR TITLE
Rogue T10 2p set bonus

### DIFF
--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -5819,6 +5819,14 @@ bool Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, AuraEffect* trigger
             }
             switch(dummySpell->Id)
             {
+                //T10 2p bonus
+                case 70752:
+ 	         {
+ 	
+ 	          triggered_spell_id = 70753;            
+ 	                       break;
+ 	         }
+
                 // Glyph of Polymorph
                 case 56375:
                 {

--- a/src/server/game/Entities/Unit/Unit.cpp
+++ b/src/server/game/Entities/Unit/Unit.cpp
@@ -6547,6 +6547,15 @@ bool Unit::HandleDummyAuraProc(Unit *pVictim, uint32 damage, AuraEffect* trigger
                     triggered_spell_id = 63975;
                     break;
                 }
+
+		 //TotT t10 2p bonus set - pouze + 15 energy, "no energy cost" nefunguje a nevim jak udelat O.o
+		case 70805:
+		{
+
+		        triggered_spell_id = 70804;						
+                         break;
+		}
+
                 // Deadly Throw Interrupt
                 case 32748:
                 {


### PR DESCRIPTION
- Rogue t10 2p set bonus - +15 energy, ale porad spell bere 15 energy -> energy se nezmeni (ale zase se neubere ..)
- Nevim jak udelat, aby TotT nestal zadnou energy (basepoints0 i SetModifierValue jsem zkoušel ..)
- Dále přidán fix na mage bonus ze setu 
